### PR TITLE
Fix for autofill in Chrome

### DIFF
--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -285,7 +285,7 @@ if (typeof document !== 'undefined') {
 
 // 清除修饰键
 function clearModifier(event) {
-  var key = event.keyCode || e.which || e.charCode,
+  var key = event.keyCode || event.which || event.charCode,
     i = _downKeys.indexOf(key);
 
   // 从列表中清除按压过的键


### PR DESCRIPTION
`e` variable was not defined in the fallback for `event.keyCode` - To reproduce, have an autofilled input in chrome