### PR TITLE
fix: 修改闭包keyup错误，修改isBindElement 判断错误

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import { _keyMap, _modifier, _downKeys, modifierMap, _mods, _handlers } from './
 
 
 let _scope = 'all'; // 默认热键范围
-let isBindElement = false; // 是否绑定节点
+let elementHasBindEvent = [] // 已绑定事件的节点记录
 
 // 返回键码
 const code = x => _keyMap[x.toLowerCase()] || _modifier[x.toLowerCase()] || x.toUpperCase().charCodeAt(0);
@@ -227,6 +227,11 @@ function dispatch(event) {
   }
 }
 
+// 判断 element 是否已经绑定事件
+function isElementBind (element) {
+  return elementHasBindEvent.some(ele => ele.isSameNode(element))
+}
+
 function hotkeys(key, option, method) {
   const keys = getKeys(key); // 需要处理的快捷键列表
   let mods = [];
@@ -243,9 +248,9 @@ function hotkeys(key, option, method) {
 
   if (Object.prototype.toString.call(option) === '[object Object]') {
     if (option.scope) scope = option.scope; // eslint-disable-line
-    if (option.element) element = option.element; // eslint-disable-line 
-    if (option.keyup) keyup = option.keyup; // eslint-disable-line 
-    if (option.keydown) keydown = option.keydown; // eslint-disable-line 
+    if (option.element) element = option.element; // eslint-disable-line
+    if (option.keyup) keyup = option.keyup; // eslint-disable-line
+    if (option.keydown) keydown = option.keydown; // eslint-disable-line
   }
 
   if (typeof option === 'string') scope = option;
@@ -275,17 +280,13 @@ function hotkeys(key, option, method) {
     });
   }
   // 在全局document上设置快捷键
-  if (typeof element !== 'undefined' && !isBindElement) {
-    isBindElement = true;
-    if (keydown) {
-      addEvent(element, 'keydown', (e) => {
+  if (typeof element !== 'undefined' && !isElementBind(element)) {
+    elementHasBindEvent.push(element)
+    addEvent(element, 'keydown', (e) => {
         dispatch(e);
-      });
-    }
+    });
     addEvent(element, 'keyup', (e) => {
-      if (keyup) {
-        dispatch(e);
-      }
+      dispatch(e);
       clearModifier(e);
     });
   }


### PR DESCRIPTION
1. keyup 闭包错误，导致第一次绑定事件没开启keyup，后续绑定的keyup无效
2.isBindElement 第一次绑定后就被赋值为true，后续即使element做了变化任然不会执行后续的addEvent
3.删除keydown/keyup的判断。在dispatch处理
4. //TODO:  考虑记录帮定事件的节点，是否需要考虑解绑？ 涉及到unbind时scope的判断。暂无较好的处理方式