### PR TITLE
Make Options type public

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ export interface FilterEvent {
   }
 }
 
-type Options = {
+export type Options = {
   scope: string,
   element?: HTMLElement | null,
   keyup?: boolean | null


### PR DESCRIPTION
First off, I'd like to thank the maintainers for the lovely little hotkeys library!

I'm writing a wrapper for `hotkeys` in TypeScript, and it receives options as an argument. I'd like to type that argument but I can't because it's not public. Unless there's a particular reason for it to be private, it should be public since there are valid use cases for it.