### PR TITLE
Make 'scope' an optional option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export interface FilterEvent {
 }
 
 type Options = {
-  scope: string,
+  scope?: string,
   element?: HTMLElement | null,
   keyup?: boolean | null
 }


### PR DESCRIPTION
First off, I'd like to thank the maintainers for the lovely little hotkey library! I ran into some difficulty when writing a Typescript wrapper for `hotkeys` due to the fact the `scope` option is required.

The documentation doesn't mention this as a required option, and in use the library works fine passing an options object without `scope`, so it should probably be marked as optional.