### PR TITLE
Change filter to accept a KeyboardEvent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,15 +10,6 @@ export interface KeyHandler {
   (keyboardEvent: KeyboardEvent, hotkeysEvent: HotkeysEvent): void
 }
 
-export interface FilterEvent {
-  target?: {
-    tagName?: string
-  }
-  srcElement?: {
-    tagName?: string
-  }
-}
-
 type Options = {
   scope?: string,
   element?: HTMLElement | null,
@@ -55,7 +46,7 @@ interface Hotkeys {
   isPressed(keyCode: string): boolean
   getPressedKeyCodes(): number[]
 
-  filter(event: FilterEvent): boolean
+  filter(event: KeyboardEvent): boolean
 }
 // https://github.com/eiriklv/react-masonry-component/issues/57
 declare var hotkeys: Hotkeys


### PR DESCRIPTION
`hotkeys.filter` filter `KeyboardEvent`s and as such the signature should reflect so. The change is specially important if one want to override the default filtering strategy.

Fixes #117.