### PR TITLE
Allow events in read only TextArea

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,6 @@ function filter(event) {
   // ignore: isContentEditable === 'true', <input> and <textarea> when readOnly state is false, <select>
   if (
     target.isContentEditable ||
-    tagName === 'TEXTAREA' ||
     ((tagName === 'INPUT' || tagName === 'TEXTAREA') && !target.readOnly)
   ) {
     flag = false;


### PR DESCRIPTION
Fix default filtering strategy to correctly allow events for text area elements when is set to read only.

Note the comment above says that the event will be ignored when the text area is no read only.