### PR TITLE
Set `ctrl` and `alt` modifiers when `altgr` is pressed

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -246,6 +246,12 @@ function dispatch(event) {
     }
   }
 
+  if (event.getModifierState('AltGraph')) {
+    _downKeys.push(17, 18);
+    _mods[17] = true;
+    _mods[18] = true;
+  }
+
   // 获取范围 默认为 `all`
   const scope = getScope();
   // 对任何快捷键都需要做的处理


### PR DESCRIPTION
This solves the issue in Firefox on Windows where hotkeys corresponding to special characters would not trigger. An example of this is `ctrl+alt+m` on a Swedish keyboard which is used to type `μ`.