### PR TITLE
Type declaration: add boolean return value from KeyHandler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export interface HotkeysEvent {
 }
 
 export interface KeyHandler {
-  (keyboardEvent: KeyboardEvent, hotkeysEvent: HotkeysEvent): void
+  (keyboardEvent: KeyboardEvent, hotkeysEvent: HotkeysEvent): void | boolean
 }
 
 type Options = {


### PR DESCRIPTION
`KeyHandler` may return a `false` per https://github.com/jaywcjlove/hotkeys/blob/master/src/main.js#L186.

This PR amends the type declaration to reflect that.

