### PR TITLE
[types] fix hotkeys.noConflict() return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ interface Hotkeys {
   getScope(): string
   deleteScope(scopeName: string): void
 
-  noConflict(): void
+  noConflict(): Hotkeys
 
   unbind(key?: string): void
   unbind(key: string, scopeName: string): void


### PR DESCRIPTION
I'm using hotkeys-js in my Typescript project but running into compilation errors when using hotkeys.noConflict(), since the type file declares that nothing is returned from that function. Changing the return type from void -> Hotkeys fixes the issue.