### PR TITLE
Make Keyhandler hotkeysEvent parameter optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export interface HotkeysEvent {
 }
 
 export interface KeyHandler {
-  (keyboardEvent: KeyboardEvent, hotkeysEvent: HotkeysEvent): void | boolean
+  (keyboardEvent: KeyboardEvent, hotkeysEvent?: HotkeysEvent): void | boolean
 }
 
 type Options = {


### PR DESCRIPTION
From the [docs](https://wangchujiang.com/hotkeys/) I take that actually both of the arguments passed to the handler are optional, but to get this library to work properly with other libraries/applications written in TypeScript it would be preferable to actually make this second event parameter optional.

Please close at will if I'm wrong!