### PR TITLE
fix: Fix problem with element scope

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,10 @@ const eachUnbind = ({
 };
 
 // 对监听对应快捷键的回调函数进行处理
-function eventHandler(event, handler, scope) {
+function eventHandler(event, handler, scope, element) {
+  if (handler.element !== element) {
+    return;
+  }
   let modifiersMatch;
 
   // 看它是否在当前范围
@@ -190,7 +193,7 @@ function eventHandler(event, handler, scope) {
 }
 
 // 处理keydown事件
-function dispatch(event) {
+function dispatch(event, element) {
   const asterisk = _handlers['*'];
   let key = event.keyCode || event.which || event.charCode;
 
@@ -278,7 +281,7 @@ function dispatch(event) {
         && ((event.type === 'keydown' && asterisk[i].keydown)
         || (event.type === 'keyup' && asterisk[i].keyup))
       ) {
-        eventHandler(event, asterisk[i], scope);
+        eventHandler(event, asterisk[i], scope, element);
       }
     }
   }
@@ -300,7 +303,7 @@ function dispatch(event) {
         }
         if (_downKeysCurrent.sort().join('') === _downKeys.sort().join('')) {
           // 找到处理内容
-          eventHandler(event, record, scope);
+          eventHandler(event, record, scope, element);
         }
       }
     }
@@ -361,13 +364,14 @@ function hotkeys(key, option, method) {
       method,
       key: keys[i],
       splitKey,
+      element,
     });
   }
   // 在全局document上设置快捷键
   if (typeof element !== 'undefined' && !isElementBind(element) && window) {
     elementHasBindEvent.push(element);
     addEvent(element, 'keydown', (e) => {
-      dispatch(e);
+      dispatch(e, element);
     });
     if (!winListendFocus) {
       winListendFocus = true;
@@ -376,7 +380,7 @@ function hotkeys(key, option, method) {
       });
     }
     addEvent(element, 'keyup', (e) => {
-      dispatch(e);
+      dispatch(e, element);
       clearModifier(e);
     });
   }

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -73,7 +73,7 @@ function __triggerKeyboardFocus(el, keyCode, opt) {
 beforeAll(async () => {
   browser = await puppeteer.launch({ args: ['--no-sandbox'] });
   page = await browser.newPage();
-});
+}, 1000 * 120);
 
 describe('\n   Hotkeys.js Test Case222.\n', () => {
   test('HTML loader', async () => {
@@ -422,7 +422,7 @@ describe('\n   Hotkeys.js Test Case222.\n', () => {
      * 解决三键组合，实现键值比对，
      * 并不是对象比对，此测试用例无法模拟
      */
-    expect(callbackA.mock.calls.length).toBe(2);
+    expect(callbackA.mock.calls.length).toBe(1);
 
     hotkeys.unbind('shift+a', callbackA);
 
@@ -430,7 +430,7 @@ describe('\n   Hotkeys.js Test Case222.\n', () => {
       shiftKey: true,
     });
 
-    expect(callbackA.mock.calls.length).toBe(2);
+    expect(callbackA.mock.calls.length).toBe(1);
 
     hotkeys('shift+a', callbackB);
 
@@ -438,7 +438,7 @@ describe('\n   Hotkeys.js Test Case222.\n', () => {
       shiftKey: true,
     });
 
-    expect(callbackB.mock.calls.length).toBe(2);
+    expect(callbackB.mock.calls.length).toBe(1);
 
     hotkeys.unbind('shift+a', callbackB);
 
@@ -446,7 +446,7 @@ describe('\n   Hotkeys.js Test Case222.\n', () => {
       shiftKey: true,
     });
 
-    expect(callbackB.mock.calls.length).toBe(2);
+    expect(callbackB.mock.calls.length).toBe(1);
   });
 
   test('HotKeys Key combination Test Case', async () => {


### PR DESCRIPTION
1. Fix the problem of element scope. Shortcut keys only take effect on specific elements
2. The default element option is document, but the test case named "unbind with method test" passes document.body triggers the event, which will bubble on the document. Previously, the callback was called twice (one triggered by document.body and one triggered by document). But now we have fixed the bug in the element scope, so the callback will only be called once
3. The default timeout of a hook in "jest" is 30s, but the startup time of "puppeter" is too long, which leads to an error when the execution time of "beforeAll" hook exceeds 30 seconds occasionally, so the timeout of "beforeAll" is extended