### PR TITLE
Fix .d.ts deleteScope declaration, fix README deleteScope

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,11 @@ Use the `hotkeys.deleteScope` method to delete a scope. This will also remove al
 ```js
 hotkeys.deleteScope('issues');
 ```
+You can use second argument, if need set new scope after deleting.
+
+```js
+hotkeys.deleteScope('issues', 'newScopeName');
+```
 
 ### unbind
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ interface Hotkeys {
 
   setScope(scopeName: string): void;
   getScope(): string;
-  deleteScope(scopeName: string): void;
+  deleteScope(scopeName: string, newScopeName?: string): void;
 
   noConflict(): Hotkeys;
 


### PR DESCRIPTION
Hello
I have seen what delete Scope support second argument, but it didn't declaration in index.d.ts file.
https://github.com/jaywcjlove/hotkeys/blob/master/src/index.js#L52

I this pull request i added correct deleteScope argument declaration.