### PR TITLE
Removed $ from install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ HotKeys.js is an input capture library with some very special features, it is ea
 You will need `Node.js` installed on your system.
 
 ```bash
-$ npm install hotkeys-js --save
+npm install hotkeys-js --save
 ```
 
 ```js


### PR DESCRIPTION
When pressing the copy button that Github provides it also copies the $ sign making pasting the command to the terminal very annoying.


https://user-images.githubusercontent.com/1312916/221875988-3baeca55-3024-4f18-ae4c-02eea4edefde.mov

